### PR TITLE
Add URL config support

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,16 @@ The theme is a lightly modified fork of Ghost’s Dawn theme, with changes focus
 
 - Theme and routing files are versioned in this repository  
 - Pushes to the `main` branch trigger Render builds when theme or configuration files are updated  
-- Render applies the updated theme automatically during deployment  
+- Render applies the updated theme automatically during deployment
 - Environment variables configure the Ghost instance dynamically
+
+### Required Environment Variables
+
+The container expects the following variables at runtime:
+
+- `PORT` – network port exposed by Ghost
+- `MAIL__SMTP__AUTH__PASS` – SMTP password for outbound mail
+- `URL` – canonical site URL used in `config.production.json`
 
 ## Live Instances
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -25,6 +25,7 @@ fi
 echo "Injecting dynamic config.production.json..."
 cat <<EOF > /var/lib/ghost/config.production.json
 {
+  "url": "${URL}",
   "server": {
     "port": ${PORT},
     "host": "0.0.0.0"


### PR DESCRIPTION
## Summary
- inject `url` into generated `config.production.json`
- document required `URL` env var

## Testing
- `bash -n entrypoint.sh`
- manual script run to verify config output

------
https://chatgpt.com/codex/tasks/task_e_6870d000d4148332a4c075126229d34d