### PR TITLE
docs(protocol): generalize sample config references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,10 +6,10 @@ This project operates under persistent rules from `docs/Black-Flag-Protocol.md` 
 Key expectations:
 
 - **Black Flag Protocol**: zero speculation, confirm states via single-question prompts, warn before costs.
-- **Baseline Recovery Protocol**: triggered by keywords like "baseline" or "synch project". Requires a State Integrity Interview, diffing the repo versus runtime, and confirming `config.sample.json` mirrors secrets.
+- **Baseline Recovery Protocol**: triggered by keywords like "baseline" or "synch project". Requires a State Integrity Interview, diffing the repo versus runtime, and confirming the sample configuration file mirrors secrets.
 - **ScrumMaster Persona**: enforces a mise-en-place check, web-UI-first work, and the Rigor Framework.
 - **Commit Style**: use `TYPE(scope): message` for all commits.
-- **Linter & Diff Checks**: run `scripts/lint-theme.sh` and keep `config.sample.json` in sync with runtime configuration.
+- **Linter & Diff Checks**: run `scripts/lint-theme.sh` and keep the sample configuration file in sync with runtime configuration.
 - **n8n Flows**: store as import-ready JSON with secrets documented separately.
 
 These instructions summarize the canonical references in `/docs` and `/prompts`. Keep this file up to date as project policies evolve.

--- a/docs/Black-Flag-Protocol.md
+++ b/docs/Black-Flag-Protocol.md
@@ -25,7 +25,7 @@
 2. Inherits Black Flag + ScrumMaster.  
 3. Mandatory State Integrity Interview (SII).  
 4. Drift census – diff last good commit, current repo, deployed runtime.  
-5. `config.sample.json` must mirror runtime secrets exactly.  
+5. The sample configuration file must mirror runtime secrets exactly.
 6. Cost/risk gate before corrective action.  
 7. Environment-adaptive fixes – Conduct an environment interview (device, OS, tools, permissions) before deciding on web or local fixes. Load or create `environmentContext.xml`.  
 8. Standardised commit messages.  
@@ -51,7 +51,7 @@
 12. Baseline keywords trigger full recovery.  
 13. State-change verification – single clarifying question.  
 14. Weekly repo audit duty.  
-15. `config.sample.json` canonical rule.  
+15. Sample configuration file canonical rule.
 16. Critical-output enumeration + user sign-off.  
 17. n8n flows delivered as import-ready JSON + secrets checklist.  
 18. Error-first minimal reproducible debugging.  

--- a/prompts/context-prompt.md
+++ b/prompts/context-prompt.md
@@ -37,7 +37,7 @@ A new model **must** perform all of the following before task execution:
 4. **Mise-en-Place Verification** – Confirm repo is lint-clean, no untracked files, GitHub `main` status is ahead/clean.
 5. **Render Health Probe** – Confirm `https://adambalm.io/ghost/` returns 200 OK.
 6. **n8n Workflow Status** – Confirm `content-pipeline-substack` is **paused**.
-7. **Baseline Divergence Scan** – Run `scripts/lint-theme.sh` and diff `config.sample.json` vs live runtime config.
+7. **Baseline Divergence Scan** – Run `scripts/lint-theme.sh` and diff the sample configuration file vs live runtime config.
 
 ---
 
@@ -92,7 +92,7 @@ Trigger phrases (case-insensitive):
 | 2 | **Inherits Black Flag + ScrumMaster** – All prior rules apply during recovery. |
 | 3 | **State Integrity Interview Required** – Confirm every repo/config fact before proceeding. |
 | 4 | **Drift Census** – Diff between: last good commit, current repo, deployed runtime. Flag divergences. |
-| 5 | **Canonical Config Check** – `config.sample.json` must match runtime configuration. |
+| 5 | **Canonical Config Check** – the sample configuration file must match runtime configuration. |
 | 6 | **Cost/Risk Gate** – Flag any cost, risk, or data-loss before acting. |
 | 7 | **Web-UI-First Fixes** – Prefer UI-based fixes unless local work is necessary. |
 | 8 | **Standardized Commits** – Use message schema (e.g., `fix(config): resync sample file`). |
@@ -118,7 +118,7 @@ Trigger phrases (case-insensitive):
 11. Baseline triggers launch full recovery  
 12. Verify discrepancies via single clarifying questions  
 13. Weekly repo audits for config & spend  
-14. `config.sample.json` must match all runtime secrets  
+14. The sample configuration file must match all runtime secrets
 15. No final spec/prompt without enumeration + signoff  
 16. n8n flows delivered as import-ready JSON + secret checklist  
 17. Minimal reproducible case for debugging  
@@ -209,7 +209,7 @@ A new model **must** perform these steps before any change:
 4. **Mise-en-Place Verification** – repo lint clean, no untracked files, GitHub status ahead/behind.  
 5. **Render Health Probe** – GET `https://adambalm.io/ghost/` (expect 200 OK).  
 6. **n8n Workflow Status** – ensure `content-pipeline-substack` remains **paused**.  
-7. **Baseline Divergence Scan** – run `scripts/lint-theme.sh` + compare `config.sample.json` vs runtime.  
+7. **Baseline Divergence Scan** – run `scripts/lint-theme.sh` + compare the sample configuration file vs runtime.
 
 Only after passing all 7 may the assistant propose tasks.
 
@@ -270,10 +270,10 @@ Trigger phrases:
 | 2 | **Inherits Black Flag + ScrumMaster** – All Black Flag rules apply; when ScrumMaster is active, its extra rules (mise-en-place, Web-UI-first, cost radar, etc.) also apply. | mem #102 |
 | 3 | **Mandatory State Integrity Interview (SII)** – The very first step is a one-question-at-a-time interrogation to confirm every fact believed about the project. No updates proceed until the user approves each answer. | mem #100 |
 | 4 | **Drift Census** – After SII, run a full diff between: 1) last confirmed “good” commit, 2) current repo state, 3) deployed runtime config. Flag every divergence (files, env-vars, n8n workflow versions, Render settings, Ghost (Pro) variables). | mem #97, #112–#115 |
-| 5 | **config.sample.json Canonical Check** – Verify that this file mirrors all runtime secrets and env-vars; any mismatch blocks baseline lock-in. | mem #113 |
+| 5 | **Canonical Config Check** – Verify that the sample configuration file mirrors all runtime secrets and env-vars; any mismatch blocks baseline lock-in. | mem #113 |
 | 6 | **Cost/Risk Gate** – For each corrective action, surface potential charges, data-loss, or downtime before asking the user to proceed. No silent expenditure is permitted. | Black Flag + ScrumMaster rules |
 | 7 | **Web-UI-First Fixes** – Prefer GitHub web edits, Render dashboard tweaks, Ghost Admin UI, and n8n SaaS UI unless a clear need for local cloning is documented. | ScrumMaster rule set |
-| 8 | **Standardised Commit Messages** – All baseline-repair commits must follow the agreed message schema (e.g., `fix(config): resync config.sample.json`). | ScrumMaster rule set |
+| 8 | **Standardised Commit Messages** – All baseline-repair commits must follow the agreed message schema (e.g., `fix(config): resync sample config`). | ScrumMaster rule set |
 | 9 | **Immediate Next Steps Section** – Every Baseline Recovery prompt or update ends with a bullet list of precise, confirmed actions to execute next—kept up-to-date in each revision. | mem #101 |
 |10 | **User Sign-off Required** – No file, prompt, or spec emerging from Baseline Recovery is “final” until the user explicitly approves after seeing a full enumeration of its contents. | mem #114 |
 |11 | **Completion Signal** – The protocol remains active—and blocks new feature work—until the user says “task complete.” | mem #76 |
@@ -300,7 +300,7 @@ Trigger phrases:
 11. **Baseline Recovery Keywords** – Hearing baseline / synch triggers Baseline Recovery Protocol.  
 12. **State-Change Verification** – Clarify discrepancies one question at a time.  
 13. **Weekly Repo Audit Duty** – Audit cost risk and config integrity weekly.  
-14. **config.sample.json Canonical Rule** – Runtime config changes must mirror in sample file.  
+14. **Sample Config Canonical Rule** – Runtime config changes must mirror in the sample file.
 15. **Critical-Output Enumeration** – No spec or prompt marked final without explicit enumeration and user sign-off.  
 16. **Best-Practice n8n Workflows** – Deliver as import-ready JSON plus secrets checklist.  
 17. **Error-First Debugging** – Produce minimal reproducible test before large changes.  


### PR DESCRIPTION
## Summary
- update project agent instructions
- generalize canonical config language across docs
- align context prompt with sample config wording

## Testing
- `scripts/lint-theme.sh`

------
https://chatgpt.com/codex/tasks/task_e_687c77bf9f1c8332aeb44f6cf12926df